### PR TITLE
fix stringify space bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ function getStringifyParams (params) {
   return Args([
     { data: Args.OBJECT | Args.Required },
     { replacer: Args.FUNCTION | Args.Optional },
-    { space: Args.NUMBER | Args.Optional, _default: DEFAULTS_OPTS.STRINGIFY.SPACE }
+    { space: Args.INT | Args.Optional, _default: DEFAULTS_OPTS.STRINGIFY.SPACE }
   ], params)
 }
 


### PR DESCRIPTION
## fix stringify space bug
```js
jsonFuture.stringify({a: 1}, null, 0)

// but space is used 2
```